### PR TITLE
fix: guard against missing editor

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -11,7 +11,8 @@
                 feedback.text('Missing API key.');
                 return;
             }
-            var content = wp.data.select('core/editor').getEditedPostContent();
+            var editorSelect = window.wp && wp.data && wp.data.select ? wp.data.select('core/editor') : null;
+            var content = editorSelect && editorSelect.getEditedPostContent ? editorSelect.getEditedPostContent() : $('#content').val();
             feedback.text('Processing...');
             progress.show();
             $.post(AiWpSeoCheck.ajaxUrl, {
@@ -21,7 +22,12 @@
             }).done(function(resp){
                 if (resp.success) {
                     if (resp.data.changed) {
-                        wp.data.dispatch('core/editor').editPost({content: resp.data.content});
+                        var editorDispatch = window.wp && wp.data && wp.data.dispatch ? wp.data.dispatch('core/editor') : null;
+                        if (editorDispatch && editorDispatch.editPost) {
+                            editorDispatch.editPost({content: resp.data.content});
+                        } else {
+                            $('#content').val(resp.data.content);
+                        }
                         if (resp.data.changes && resp.data.changes.length) {
                             var list = '<ul>';
                             resp.data.changes.forEach(function(change){

--- a/resources/js/admin.js
+++ b/resources/js/admin.js
@@ -11,7 +11,8 @@
                 feedback.text('Missing API key.');
                 return;
             }
-            var content = wp.data.select('core/editor').getEditedPostContent();
+            var editorSelect = window.wp && wp.data && wp.data.select ? wp.data.select('core/editor') : null;
+            var content = editorSelect && editorSelect.getEditedPostContent ? editorSelect.getEditedPostContent() : $('#content').val();
             feedback.text('Processing...');
             progress.show();
             $.post(AiWpSeoCheck.ajaxUrl, {
@@ -21,7 +22,12 @@
             }).done(function(resp){
                 if (resp.success) {
                     if (resp.data.changed) {
-                        wp.data.dispatch('core/editor').editPost({content: resp.data.content});
+                        var editorDispatch = window.wp && wp.data && wp.data.dispatch ? wp.data.dispatch('core/editor') : null;
+                        if (editorDispatch && editorDispatch.editPost) {
+                            editorDispatch.editPost({content: resp.data.content});
+                        } else {
+                            $('#content').val(resp.data.content);
+                        }
                         if (resp.data.changes && resp.data.changes.length) {
                             var list = '<ul>';
                             resp.data.changes.forEach(function(change){


### PR DESCRIPTION
## Summary
- avoid JS error when block editor isn't available by falling back to classic content field

## Testing
- `npm test` (fails: ENOENT package.json)
- `composer test` (fails: Command "test" is not defined)


------
https://chatgpt.com/codex/tasks/task_e_689de5016470832e84b16a1cf1ecd5ac