### PR TITLE
fix: detect content in acf page blocks

### DIFF
--- a/ai-wp-seo-check.php
+++ b/ai-wp-seo-check.php
@@ -5,7 +5,7 @@
  * Version:           0.1.3
  * Requires at least: 6.3
  * Requires PHP:      8.1
- * Author:            OpenAI
+ * Author:            Digivate
  * Text Domain:       ai-wp-seo-check
  */
 

--- a/ai-wp-seo-check.php
+++ b/ai-wp-seo-check.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       AI WP SEO Check
  * Description:       Adjust post and page content SEO using OpenAI suggestions.
- * Version:           0.1.2
+ * Version:           0.1.3
  * Requires at least: 6.3
  * Requires PHP:      8.1
  * Author:            OpenAI
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 exit; // Exit if accessed directly.
 }
 
-define( 'AI_WP_SEO_CHECK_VERSION', '0.1.2' );
+define( 'AI_WP_SEO_CHECK_VERSION', '0.1.3' );
 define( 'AI_WP_SEO_CHECK_PATH', plugin_dir_path( __FILE__ ) );
 define( 'AI_WP_SEO_CHECK_URL', plugin_dir_url( __FILE__ ) );
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -12,7 +12,25 @@
                 return;
             }
             var editorSelect = window.wp && wp.data && wp.data.select ? wp.data.select('core/editor') : null;
-            var content = editorSelect && editorSelect.getEditedPostContent ? editorSelect.getEditedPostContent() : $('#content').val();
+            var content = editorSelect && editorSelect.getEditedPostContent
+                ? editorSelect.getEditedPostContent()
+                : $('#content').val();
+            if (!content || !content.trim()) {
+                content = '';
+                $('.acf-field-wysiwyg textarea.wp-editor-area:not(:disabled)').not('#content').each(function(){
+                    var val = $(this).val();
+                    var id = $(this).attr('id');
+                    if (typeof tinyMCE !== 'undefined') {
+                        var editor = tinyMCE.get(id);
+                        if (editor && !editor.isHidden()) {
+                            val = editor.getContent();
+                        }
+                    }
+                    if (val) {
+                        content += val + "\n";
+                    }
+                });
+            }
             feedback.text('Processing...');
             progress.show();
             $.post(AiWpSeoCheck.ajaxUrl, {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, openai
 Requires at least: 6.3
 Tested up to: 6.4
 Requires PHP: 8.1
-Stable tag: 0.1.2
+Stable tag: 0.1.3
 License: GPLv2 or later
 
 Adjust post and page content SEO using OpenAI suggestions.
@@ -22,6 +22,9 @@ AI WP SEO Check helps you improve grammar, spelling, and on-page SEO in your pos
 No. You can review the suggested content before updating the post.
 
 == Changelog ==
+= 0.1.3 =
+* Detect content saved in ACF Page Blocks when the main editor is empty.
+
 = 0.1.2 =
 * Expand prompt to optimize SEO in addition to grammar corrections.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === AI WP SEO Check ===
-Contributors: openai
+Contributors: digivate
 Tags: seo, ai, openai
 Requires at least: 6.3
 Tested up to: 6.4

--- a/resources/js/admin.js
+++ b/resources/js/admin.js
@@ -12,7 +12,25 @@
                 return;
             }
             var editorSelect = window.wp && wp.data && wp.data.select ? wp.data.select('core/editor') : null;
-            var content = editorSelect && editorSelect.getEditedPostContent ? editorSelect.getEditedPostContent() : $('#content').val();
+            var content = editorSelect && editorSelect.getEditedPostContent
+                ? editorSelect.getEditedPostContent()
+                : $('#content').val();
+            if (!content || !content.trim()) {
+                content = '';
+                $('.acf-field-wysiwyg textarea.wp-editor-area:not(:disabled)').not('#content').each(function(){
+                    var val = $(this).val();
+                    var id = $(this).attr('id');
+                    if (typeof tinyMCE !== 'undefined') {
+                        var editor = tinyMCE.get(id);
+                        if (editor && !editor.isHidden()) {
+                            val = editor.getContent();
+                        }
+                    }
+                    if (val) {
+                        content += val + "\n";
+                    }
+                });
+            }
             feedback.text('Processing...');
             progress.show();
             $.post(AiWpSeoCheck.ajaxUrl, {


### PR DESCRIPTION
## Summary
- capture content from ACF Page Block WYSIWYG fields when main editor is empty
- bump plugin version to 0.1.3
- document ACF support in changelog

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l ai-wp-seo-check.php`
- `php -l src/Admin/MetaBox.php`


------
https://chatgpt.com/codex/tasks/task_e_689debe26f9c832e97575ba5920e2c60